### PR TITLE
feature (messenger) Parse train's journey reference for miku app integration

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
 			<thead>
 				<tr>
 					<th>#</th>
-					<th id="type" class="type">Liniennummer</th>
+					<th id="type" class="type">Zug</th>
 					<th id="from">Von</th>
 					<th id="fromPasslist" class="passlist">Stationen</th>
 					<th id="arrivalTime">Ankunftszeit</th>

--- a/javascript/config_sample.js
+++ b/javascript/config_sample.js
@@ -2,3 +2,4 @@
 
 // paste api key here and rename file to config.js
 let apiKey = "";
+let mikuLink = "";

--- a/javascript/data.object.js
+++ b/javascript/data.object.js
@@ -8,6 +8,8 @@ let data = {
 
 	apiKey: "",
 
+    mikuLink: "",
+
 	requestParser: {},
 
 	/**
@@ -30,8 +32,12 @@ let data = {
 		that.requestParser = requestParser;
 
 		if(this.apiKey.length === 0) {
-			console.log("No API Key specified!")
+			console.log("No API Key specified!");
 			return false;
+		}
+    
+		if(this.mikuLink.length === 0) {
+			console.log("No Miku URL specified!");
 		}
 
 		let arrivalsPromise = this.fetchApi("arrival");

--- a/javascript/main.js
+++ b/javascript/main.js
@@ -1,6 +1,7 @@
 'use strict';
 
 data.apiKey = apiKey;
+data.mikuLink = mikuLink;
 
 const reloadInterval = 30;
 

--- a/javascript/stationBoard-view.js
+++ b/javascript/stationBoard-view.js
@@ -96,7 +96,7 @@ let stationBoardView = {
         }
 
         if (journeyNumber !== '') {
-            let infoUrl = "https://80e05b96-2d12-4945-b772-e22e7e1dd377-miku.app.sbb.ch/#/fahrten/direkt/" + journeyNumber;
+            let infoUrl = mikuLink + journeyNumber;
             let lineLink = document.createElement('a');
 
             lineLink.setAttribute('href', infoUrl);

--- a/javascript/stationBoard-view.js
+++ b/javascript/stationBoard-view.js
@@ -87,7 +87,7 @@ let stationBoardView = {
     createMikuLink: function (train) {
         let journey;
         let journeyNumber = '';
-        if (train.journeyRef !== ''){
+        if (!mikuLink == '' && train.journeyRef !== ''){
             journey = train.journeyRef.split(":");
             journeyNumber = journey.pop();
         }

--- a/javascript/stationBoard-view.js
+++ b/javascript/stationBoard-view.js
@@ -84,17 +84,13 @@ let stationBoardView = {
 		}
 		return platform;
 	},
-	createTypeField: function (train) {
-		let type = document.createElement("td");
-		type.classList.add("type");
-
+    createMikuLink: function (train) {
         let journey;
         let journeyNumber = '';
         if (train.journeyRef !== ''){
             journey = train.journeyRef.split(":");
             journeyNumber = journey.pop();
         }
-
         if (journeyNumber !== '') {
             let infoUrl = mikuLink + journeyNumber;
             let lineLink = document.createElement('a');
@@ -103,10 +99,22 @@ let stationBoardView = {
             lineLink.setAttribute('target', "_blank");
             lineLink.innerHTML = train.lineName;
 
+            return lineLink;
+        } else {
+            return undefined;
+        }
+    },
+	createTypeField: function (train) {
+		let type = document.createElement("td");
+		type.classList.add("type");
+
+        let lineLink = this.createMikuLink(train);
+        if (lineLink) {
             type.appendChild(lineLink);
         } else {
             type.appendChild(document.createTextNode(train.lineName));
         }
+
 		return type;
 	},
 	createFromField: function (train) {

--- a/javascript/stationBoard-view.js
+++ b/javascript/stationBoard-view.js
@@ -87,7 +87,7 @@ let stationBoardView = {
     createMikuLink: function (train) {
         let journey;
         let journeyNumber = '';
-        if (!mikuLink == '' && train.journeyRef !== ''){
+        if (mikuLink !== '' && train.journeyRef !== ''){
             journey = train.journeyRef.split(":");
             journeyNumber = journey.pop();
         }

--- a/javascript/stationBoard-view.js
+++ b/javascript/stationBoard-view.js
@@ -88,7 +88,16 @@ let stationBoardView = {
 		let type = document.createElement("td");
 		type.classList.add("type");
 
-		type.appendChild(document.createTextNode(train.lineName));
+        let journey = train.journeyRef.split(":");
+        let journeyNumber = journey.pop()
+        let infoUrl = "https://80e05b96-2d12-4945-b772-e22e7e1dd377-miku.app.sbb.ch/#/fahrten/direkt/" + journeyNumber;
+        let lineLink = document.createElement('a');
+
+        lineLink.setAttribute('href', infoUrl);
+        lineLink.setAttribute('target', "_blank");
+        lineLink.innerHTML = train.lineName;
+
+		type.appendChild(lineLink);
 
 		return type;
 	},

--- a/javascript/stationBoard-view.js
+++ b/javascript/stationBoard-view.js
@@ -88,17 +88,25 @@ let stationBoardView = {
 		let type = document.createElement("td");
 		type.classList.add("type");
 
-        let journey = train.journeyRef.split(":");
-        let journeyNumber = journey.pop()
-        let infoUrl = "https://80e05b96-2d12-4945-b772-e22e7e1dd377-miku.app.sbb.ch/#/fahrten/direkt/" + journeyNumber;
-        let lineLink = document.createElement('a');
+        let journey;
+        let journeyNumber = '';
+        if (train.journeyRef !== ''){
+            journey = train.journeyRef.split(":");
+            journeyNumber = journey.pop();
+        }
 
-        lineLink.setAttribute('href', infoUrl);
-        lineLink.setAttribute('target', "_blank");
-        lineLink.innerHTML = train.lineName;
+        if (journeyNumber !== '') {
+            let infoUrl = "https://80e05b96-2d12-4945-b772-e22e7e1dd377-miku.app.sbb.ch/#/fahrten/direkt/" + journeyNumber;
+            let lineLink = document.createElement('a');
 
-		type.appendChild(lineLink);
+            lineLink.setAttribute('href', infoUrl);
+            lineLink.setAttribute('target', "_blank");
+            lineLink.innerHTML = train.lineName;
 
+            type.appendChild(lineLink);
+        } else {
+            type.appendChild(document.createTextNode(train.lineName));
+        }
 		return type;
 	},
 	createFromField: function (train) {

--- a/styles/mobile.css
+++ b/styles/mobile.css
@@ -1,19 +1,14 @@
-@media screen and (max-device-width : 480px) {
+@media screen and (max-device-width: 480px) {
     body {
         font-size: 0.7em;
     }
 
-    a:hover {
-        color: hotpink;
-    }
-
     .stationtable {
-        margin:  0 0 0 0 ;
+        margin: 0 0 0 0;
         width: 100%;
     }
 
     .stationtable td {
-
         border: solid thin #dddddd;
         padding: 20px 5px;
     }
@@ -21,10 +16,6 @@
     .passlist {
         display: none;
     }
-
-    /* .type { */
-    /*     display: none; */
-    /* } */
 
     .lock {
         display: none;
@@ -60,6 +51,4 @@
     #countdown {
         /*display: none;*/
     }
-
-
 }

--- a/styles/mobile.css
+++ b/styles/mobile.css
@@ -3,6 +3,10 @@
         font-size: 0.7em;
     }
 
+    a:hover {
+        color: hotpink;
+    }
+
     .stationtable {
         margin:  0 0 0 0 ;
         width: 100%;
@@ -18,9 +22,9 @@
         display: none;
     }
 
-    .type {
-        display: none;
-    }
+    /* .type { */
+    /*     display: none; */
+    /* } */
 
     .lock {
         display: none;

--- a/styles/style.css
+++ b/styles/style.css
@@ -4,6 +4,10 @@ body {
     margin: 0;
 }
 
+a:hover {
+    color: hotpink;
+}
+
 #version {
 	font-style: italic;
 }


### PR DESCRIPTION
## What is this?
This allows the line number to open up the sbb miku tool in order to get more information such as the formation and exact delays. 

Additional changes:

Change the title "Liniennummer" to "Zug"
Show the type field on the mobile view (works better with new shortened column name)
Hover highlighting for new link

## Demo
![demo](https://i.imgur.com/FCxMmnP.gif)